### PR TITLE
Fix: TypeError during load if precompilation is disabled

### DIFF
--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -65,7 +65,7 @@ function __lookup_kwbody__(mnokw::Method)
 end
 
 function _precompile_()
-    ccall(:jl_generating_output, Cint, ()) == 1 || return nothing
+    ccall(:jl_generating_output, Cint, ()) == 1 || return false
     Base.precompile(Tuple{Core.kwftype(typeof(Type)),NamedTuple{(:order, :alias, :options),Tuple{Int64,String,RuleOptions}},Type{Rule},NonTerminal,Array{Any,1}})
     Base.precompile(Tuple{Type{PrepareAnonTerminals},Array{TerminalDef,1},Set{String},Dict{Any,Any},Int64,Nothing})
     Base.precompile(Tuple{Type{TraditionalLexer},LexerConf})

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -8,7 +8,7 @@ macro warnpcfail(ex::Expr)
     quote
         pcresult = $(esc(ex))
         if !isnothing(pcresult)
-            $(esc(ex)) || @warn """precompile directive
+             pcresult || @warn """precompile directive
              $($(Expr(:quote, ex)))
              failed. Please report an issue in $($modl) (after checking for duplicates) or remove this directive.""" _file=$file _line=$line
         end

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -6,9 +6,12 @@ macro warnpcfail(ex::Expr)
     file = __source__.file === nothing ? "?" : String(__source__.file)
     line = __source__.line
     quote
-        $(esc(ex)) || @warn """precompile directive
-     $($(Expr(:quote, ex)))
- failed. Please report an issue in $($modl) (after checking for duplicates) or remove this directive.""" _file=$file _line=$line
+        pcresult = $(esc(ex))
+        if !isnothing(pcresult)
+            $(esc(ex)) || @warn """precompile directive
+             $($(Expr(:quote, ex)))
+             failed. Please report an issue in $($modl) (after checking for duplicates) or remove this directive.""" _file=$file _line=$line
+        end
     end
 end
 
@@ -65,7 +68,7 @@ function __lookup_kwbody__(mnokw::Method)
 end
 
 function _precompile_()
-    ccall(:jl_generating_output, Cint, ()) == 1 || return false
+    ccall(:jl_generating_output, Cint, ()) == 1 || return nothing
     Base.precompile(Tuple{Core.kwftype(typeof(Type)),NamedTuple{(:order, :alias, :options),Tuple{Int64,String,RuleOptions}},Type{Rule},NonTerminal,Array{Any,1}})
     Base.precompile(Tuple{Type{PrepareAnonTerminals},Array{TerminalDef,1},Set{String},Dict{Any,Any},Int64,Nothing})
     Base.precompile(Tuple{Type{TraditionalLexer},LexerConf})


### PR DESCRIPTION
fixes the following error by checking the precompilation result only if its enabled
```
 ERROR: LoadError:
 TypeError: non-boolean (Nothing) used in boolean context
  Stacktrace:
   [1] top-level scope
     @ ~/.julia/packages/Lerche/fVtVd/src/precompile.jl:9
    [2] include
      @ ./Base.jl:419 [inlined]
    [3] _require(pkg::Base.PkgId)
 
```