### PR TITLE
Parsing signed-float error

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["James.Hester <jxh@ansto.gov.au>"]
 version = "0.5.3"
 
 [deps]
+AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 

--- a/src/Lerche.jl
+++ b/src/Lerche.jl
@@ -2,6 +2,8 @@ module Lerche
 
 using DataStructures  #For Stack when parsing
 using Logging         #Because Lark does
+using AbstractTrees
+using AbstractTrees: print_tree
 
 export Tree, Token, Interpreter,Visitor,Transformer, visit_children, visit,transform
 export Transformer_InPlace, Transformer_InPlaceRecursive,Visitor_Recursive
@@ -10,6 +12,7 @@ export UnexpectedInput
 export Lark
 export visit_tokens   #So users can override default trait for Transformers
 export @inline_rule, @rule
+export print_tree
 #==
 
 Lerche ("Lark" in German) is a port of the Python Lark package to
@@ -37,6 +40,7 @@ include("parsers/lalr_parser.jl")
 include("parser_frontends.jl")
 include("load_grammar.jl")
 include("lark.jl")
+include("print_tree.jl")
 
 # Compatibility for Julia < 1.4
 

--- a/src/grammar.jl
+++ b/src/grammar.jl
@@ -44,7 +44,7 @@ is_terminal(::IsNotTerminal,l) = false
 
 # == Rule options == #
 
-struct RuleOptions
+mutable struct RuleOptions
     keep_all_tokens::Bool
     expand1::Bool
     priority::Union{Int,Nothing}

--- a/src/load_grammar.jl
+++ b/src/load_grammar.jl
@@ -840,7 +840,7 @@ end
 options_from_rule(name, params, x...) = begin
     if length(x) > 1
         priority, expansions = x
-        priority = parse(Int,priority)
+        priority = Base.parse(Int,priority)
     else
         expansions = x[1]
         priority = nothing

--- a/src/parsers/lalr_analysis.jl
+++ b/src/parsers/lalr_analysis.jl
@@ -291,7 +291,7 @@ compute_lalr1_states(l::LALR_Analyzer) = begin
         for (la, rules) in state.lookaheads
             if length(rules) > 1
                 # Try to resolve conflict based on priority
-                p = [(r.options.priority || 0, r) for r in rules]
+                p = [(r.options.priority !== nothing ? r.options.priority : 0, r) for r in rules]
                 sort!(p,by=r -> r[1], rev=true)
                 best, second_best = p[1:2]
                 if best[1] > second_best[1]

--- a/src/print_tree.jl
+++ b/src/print_tree.jl
@@ -1,0 +1,7 @@
+AbstractTrees.children(t::Lerche.Tree) = t.children
+function AbstractTrees.printnode(io::IO, t::Lerche.Tree)
+	print(io, t.data)
+end
+function AbstractTrees.printnode(io::IO, t::Lerche.Token)
+    print(io, t.value)
+end

--- a/test/test_parser.jl
+++ b/test/test_parser.jl
@@ -59,7 +59,34 @@ make_parser_test(lexer,parser) = begin
     make_lark(grammar;kwargs...) = begin
         Lark(grammar,lexer=lexer,parser=parser,propagate_positions=true;kwargs...)
     end
-    
+    @testset "test_priority" begin
+        g = Lark("""
+object: genericobj
+        | list
+        | ESCAPED_STRING
+        | SIGNED_FLOAT
+        | INT
+        | true
+        | false
+        | null
+
+genericobj : "{" ["\\"type\\"" ":" object "," ]"\\"fields\\"" ":" list "}"
+
+list : "[" [object ("," object)*] "]"
+true : "true"
+false : "false"
+null : "null"
+
+%import common.ESCAPED_STRING
+%import common.INT
+%import common.SIGNED_FLOAT
+%import common.WS
+%ignore WS
+""", start="object", parser="lalr")
+        r = Lerche.parse(g,"2.0")
+        @test r.children[1].data === 2.0
+    end
+
     @testset "Test expansions" begin
     #Test expand1
     g = Lark("""start: a

--- a/test/test_parser.jl
+++ b/test/test_parser.jl
@@ -85,6 +85,7 @@ null : "null"
 """, start="object", parser="lalr")
         r = Lerche.parse(g,"2.0")
         @test r.children[1].data === 2.0
+        print_tree(r)
     end
 
     @testset "Test expansions" begin
@@ -95,6 +96,7 @@ null : "null"
                  """,parser="lalr",lexer="standard",debug=true)
 
     r = Lerche.parse(g,"x")
+    print_tree(r)
     @test r.children[1].data == "b"
     
     g = Lark("""start: a


### PR DESCRIPTION
HELP NEEDED.

## This PR contains
* Fixed 3 bugs.
    1. can not mutate options when using keyword arguments `priority="invert"`.
    2. fix #27 
    3. fix a priority comparing issue, non-boolean used in comparing.
* Adding a tree printing functionality to help debugging, which I find very helpful. (NOTE: `AbstractTrees` is a very light weighted dependency, the increased loading time is negligible)
```
julia> Lerche.print_tree(types; maxdepth=10)
object
└─ genericobj3
   ├─ list
   │  ├─ object
   │  │  └─ genericobj3
   │  │     ├─ list
   │  │     │  ├─ object
   │  │     │  │  └─ list
   │  │     │  │     └─ object
   │  │     │  │        └─ 0
   │  │     │  └─ object
   │  │     │     └─ list
   │  │     └─ "Core.Array{Core.String, 1}"
   │  └─ object
   │     └─ genericobj3
   │        ├─ list
   │        │  ├─ object
   │        │  │  └─ list
   │        │  └─ object
   │        │     └─ list
   │        └─ "Base.Dict{Core.String, Core.Tuple{Core.Array{Core.String, 1}, Core.Array{Core.String, 1}}}"
   └─ "JugsawIR.TypeTable"
```

The following is a minimum one
```julia
julia> g = Lark("""start: a
                       ?a: b
                       b: "x"
                    """,parser="lalr",lexer="standard",debug=true);

julia> r = Lerche.parse(g,"x")
Tree(start, Any[Tree(b, Union{Token, Tree}[])
])


julia> print_tree(r)
start
└─ b
```

## One issue not yet resolved
An unfixed one is kind of related to #29 . The parser does not know how to parse "SIGNED_FLOAT" and "INT" properly.

Setting priority does not work. Why it always parse INT first?
Even if I define integer and float manually and set their priority manually, the parser still parse integer first.