### PR TITLE
Update compat entry for DataStructures 

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,6 @@ Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 
 [compat]
-DataStructures = "^0.18.0"
+DataStructures = "0.18, 0.19"
 julia = "1.2"
 PrecompileTools = "1.2.0"


### PR DESCRIPTION
Update Project.toml with the compat entry,
```
DataStructures = "0.18, 0.19"
```
This syntax will allow any version in the 0.18.x or 0.19.x series. I did not test this update.